### PR TITLE
Fix checkerboard visualization

### DIFF
--- a/robot_calibration/src/finders/checkerboard_finder.cpp
+++ b/robot_calibration/src/finders/checkerboard_finder.cpp
@@ -186,7 +186,7 @@ bool CheckerboardFinder::findInternal(robot_calibration_msgs::CalibrationData * 
     sensor_msgs::PointCloud2Modifier cloud_mod(cloud);
     cloud_mod.setPointCloud2FieldsByString(1, "xyz");
     cloud_mod.resize(points_x_ * points_y_);
-    sensor_msgs::PointCloud2Iterator<float> iter_cloud(cloud_, "x");
+    sensor_msgs::PointCloud2Iterator<float> iter_cloud(cloud, "x");
 
     // Set msg size
     int idx_cam = msg->observations.size() + 0;

--- a/robot_calibration/src/finders/plane_finder.cpp
+++ b/robot_calibration/src/finders/plane_finder.cpp
@@ -127,6 +127,9 @@ bool PlaneFinder::find(robot_calibration_msgs::CalibrationData * msg)
   tf2_ros::Buffer tfBuffer;
   tf2_ros::TransformListener tfListener(tfBuffer);  // This should probably be class member
 
+  // Give some time to get TFs
+  ros::Duration(1.0).sleep();
+
   //  Remove any point that is invalid or not with our tolerance
   size_t num_points = cloud_.width * cloud_.height;
   sensor_msgs::PointCloud2ConstIterator<float> xyz(cloud_, "x");
@@ -164,6 +167,7 @@ bool PlaneFinder::find(robot_calibration_msgs::CalibrationData * msg)
       {
         ROS_ERROR("%s", ex.what());
         ros::Duration(1.0).sleep();
+        continue;
       }
     }
     else
@@ -190,6 +194,7 @@ bool PlaneFinder::find(robot_calibration_msgs::CalibrationData * msg)
 
   // Determine number of points to output
   size_t points_total = std::min(static_cast<size_t>(points_max_), j);
+  ROS_INFO_STREAM("Got " << j << " points from plane, using " << points_total);
 
   // Create PointCloud2 to publish
   sensor_msgs::PointCloud2 viz_cloud;


### PR DESCRIPTION
Fixes checkerboard PointCloud2 visualization message, previously was composed of only zeros.

In turn, this was also affecting the debug part of the calibration msg, the first points were being overriden.