### PR TITLE
Update led_finder.cpp

### DIFF
--- a/robot_calibration/src/finders/led_finder.cpp
+++ b/robot_calibration/src/finders/led_finder.cpp
@@ -185,7 +185,7 @@ bool LedFinder::find(robot_calibration_msgs::CalibrationData * msg)
   while (true)
   {
     // Toggle LED to next state
-    code_idx = (code_idx + 1) % 8;
+    code_idx = (code_idx + 1) % codes_.size();
     command.led_code = codes_[code_idx];
     client_->sendGoal(command);
     client_->waitForResult(ros::Duration(10.0));


### PR DESCRIPTION
To use any number of led's other than 4 in led finder code.

In the previous code, to use the led finder feature, 4 led's had to be used. For smaller number than 4 led's, it will show a TF problem, and for bigger number than 4 led's it will not consider only.
This has been corrected with current change.