### PR TITLE
Use multiple checkerboards

### DIFF
--- a/robot_calibration/include/robot_calibration/capture/checkerboard_finder.h
+++ b/robot_calibration/include/robot_calibration/capture/checkerboard_finder.h
@@ -65,6 +65,8 @@ private:
 
   bool output_debug_;   /// Should we output debug image/cloud?
 
+  std::string frame_id_;   /// Name of checkerboard frame
+
   std::string camera_sensor_name_;
   std::string chain_sensor_name_;
 };

--- a/robot_calibration/src/finders/checkerboard_finder.cpp
+++ b/robot_calibration/src/finders/checkerboard_finder.cpp
@@ -58,6 +58,9 @@ bool CheckerboardFinder::init(const std::string& name,
   // Should we include debug image/cloud in observations
   nh.param<bool>("debug", output_debug_, false);
 
+  // Name of checkerboard frame that will be used during optimization
+  nh.param<std::string>("frame_id", frame_id_, "checkerboard");
+
   // Name of the sensor model that will be used during optimization
   nh.param<std::string>("camera_sensor_name", camera_sensor_name_, "camera");
   nh.param<std::string>("chain_sensor_name", chain_sensor_name_, "arm");
@@ -201,7 +204,7 @@ bool CheckerboardFinder::findInternal(robot_calibration_msgs::CalibrationData * 
 
     // Fill in the headers
     rgbd.header = cloud_.header;
-    world.header.frame_id = "checkerboard";
+    world.header.frame_id = frame_id_;
 
     // Fill in message
     sensor_msgs::PointCloud2ConstIterator<float> xyz(cloud_, "x");


### PR DESCRIPTION
Hello. I am Naoki Hiraoka, robot_calibration user.

This pull request is to use multiple checkerboards.

For calibrating a dual-arm robot, we have to capture data with a checkerboard attached to its right arm, and then capture data with another checkerboard attached to its left arm, and then solve the optimization together.
This pull request gives different ```frame_id``` to each checkerboard and enables the optimizer to distinguish the frames of the checkerboards.

Multiple checkerboards can be used with modified capture.yaml like below.
```
features:
  rarm_checkerboard_finder:
    type: robot_calibration/CheckerboardFinder
    topic: /head_camera/depth_registered/points
    camera_sensor_name: camera
    chain_sensor_name: rarm
    frame_id: rarm_checkerboard
  larm_checkerboard_finder:
    type: robot_calibration/CheckerboardFinder
    topic: /head_camera/depth_registered/points
    camera_sensor_name: camera
    chain_sensor_name: larm
    frame_id: larm_checkerboard
```