### PR TITLE
Enable to change driver name

### DIFF
--- a/robot_calibration/include/robot_calibration/capture/depth_camera.h
+++ b/robot_calibration/include/robot_calibration/capture/depth_camera.h
@@ -46,10 +46,12 @@ public:
                                           this);
 
     // Get parameters of drivers
-    if (!n.getParam("/head_camera/driver/z_offset_mm", z_offset_mm_) ||
-        !n.getParam("/head_camera/driver/z_scaling", z_scaling_))
+    std::string driver_name;
+    n.param<std::string>("camera_driver", driver_name, "/head_camera/driver");
+    if (!n.getParam(driver_name+"/z_offset_mm", z_offset_mm_) ||
+        !n.getParam(driver_name+"/z_scaling", z_scaling_))
     {
-      ROS_ERROR("/head_camera/driver is not set, are drivers running?");
+      ROS_ERROR("%s is not set, are drivers running?",driver_name.c_str());
       z_offset_mm_ = 0;
       z_scaling_ = 1;
     }


### PR DESCRIPTION
Hello. I am Naoki Hiraoka, robot_calibration user.

This pull request is to use cameras other than ```/head_camera```.

In the previous code, driver_name is fixed to ```/head_camera/driver```, so other cameras cannot be used.
This pull request fixed this problem.

Driver name can be configured by capture.yaml like below.
```
features:
  checkerboard_finder:
    type: robot_calibration/CheckerboardFinder
    topic: /camera/depth_registered/points
    camera_info_topic: /camera/depth/camera_info
    camera_driver: /camera/driver
    camera_sensor_name: camera
    chain_sensor_name: arm
```