### PR TITLE
Fix calculation of frame offset

### DIFF
--- a/robot_calibration/src/calibration_offset_parser.cpp
+++ b/robot_calibration/src/calibration_offset_parser.cpp
@@ -252,13 +252,6 @@ std::string CalibrationOffsetParser::updateURDF(const std::string &urdf)
       std::vector<double> xyz(3, 0.0);
       std::vector<double> rpy(3, 0.0);
 
-      xyz[0] = frame_offset.p.x();
-      xyz[1] = frame_offset.p.y();
-      xyz[2] = frame_offset.p.z();
-
-      // Get roll, pitch, yaw about fixed axis
-      frame_offset.M.GetRPY(rpy[0], rpy[1], rpy[2]);
-
       // String streams for output
       std::stringstream xyz_ss, rpy_ss;
 
@@ -273,52 +266,45 @@ std::string CalibrationOffsetParser::updateURDF(const std::string &urdf)
         std::vector<std::string> xyz_pieces;
         boost::split(xyz_pieces, xyz_str, boost::is_any_of(" "));
 
-        if (xyz_pieces.size() == 3)
-        {
-          // Update xyz
-          for (int i = 0; i < 3; ++i)
-          {
-            double x = double(boost::lexical_cast<double>(xyz_pieces[i]) + xyz[i]);
-            if (i > 0)
-              xyz_ss << " ";
-            xyz_ss << std::fixed << std::setprecision(precision) << x;
-          }
-        }
-        else
-        {
-          // Create xyz
-          for (int i = 0; i < 3; ++i)
-          {
-            if (i > 0)
-              xyz_ss << " ";
-            xyz_ss << std::fixed << std::setprecision(precision) << xyz[i];
-          }
-        }
-
         // Split out rpy of origin, break into 3 strings
         std::vector<std::string> rpy_pieces;
         boost::split(rpy_pieces, rpy_str, boost::is_any_of(" "));
 
+        KDL::Frame origin(KDL::Rotation::Identity(), KDL::Vector::Zero());
+        if (xyz_pieces.size() == 3)
+        {
+          origin.p = KDL::Vector(boost::lexical_cast<double>(xyz_pieces[0]), boost::lexical_cast<double>(xyz_pieces[1]), boost::lexical_cast<double>(xyz_pieces[2]));
+        }
+
         if (rpy_pieces.size() == 3)
         {
-          // Update rpy
-          for (int i = 0; i < 3; ++i)
-          {
-            double x = double(boost::lexical_cast<double>(rpy_pieces[i]) + rpy[i]);
-            if (i > 0)
-              rpy_ss << " ";
-            rpy_ss << std::fixed << std::setprecision(precision) << x;
-          }
+          origin.M = KDL::Rotation::RPY(boost::lexical_cast<double>(rpy_pieces[0]), boost::lexical_cast<double>(rpy_pieces[1]), boost::lexical_cast<double>(rpy_pieces[2]));
         }
-        else
+
+        // Update
+        origin = origin * frame_offset;
+
+        xyz[0] = origin.p.x();
+        xyz[1] = origin.p.y();
+        xyz[2] = origin.p.z();
+
+        // Get roll, pitch, yaw about fixed axis
+        origin.M.GetRPY(rpy[0], rpy[1], rpy[2]);
+
+        // Update xyz
+        for (int i = 0; i < 3; ++i)
         {
-          // Create rpy
-          for (int i = 0; i < 3; ++i)
-          {
-            if (i > 0)
-              rpy_ss << " ";
-            rpy_ss << std::fixed << std::setprecision(precision) << rpy[i];
-          }
+          if (i > 0)
+            xyz_ss << " ";
+          xyz_ss << std::fixed << std::setprecision(precision) << xyz[i];
+        }
+
+        // Update rpy
+        for (int i = 0; i < 3; ++i)
+        {
+          if (i > 0)
+            rpy_ss << " ";
+          rpy_ss << std::fixed << std::setprecision(precision) << rpy[i];
         }
 
         // Update xml
@@ -327,6 +313,13 @@ std::string CalibrationOffsetParser::updateURDF(const std::string &urdf)
       }
       else
       {
+        xyz[0] = frame_offset.p.x();
+        xyz[1] = frame_offset.p.y();
+        xyz[2] = frame_offset.p.z();
+
+        // Get roll, pitch, yaw about fixed axis
+        frame_offset.M.GetRPY(rpy[0], rpy[1], rpy[2]);
+
         // No existing origin, create an element with attributes
         origin_xml = new TiXmlElement("origin");
 


### PR DESCRIPTION
Hello. I am Naoki Hiraoka, robot_calibration user.

This pull request fixes the method of applying frame offset in ```updateURDF``` and ```getChainFK```.

In the previous code, frames are calculated as following
```
In updateURDF
[updated frame].x = [original frame].x + [offset frame].x
[updated frame].y = [original frame].y + [offset frame].y
[updated frame].z = [original frame].z + [offset frame].z
[updated frame].roll = [original frame].roll + [offset frame].roll
[updated frame].pitch = [original frame].pitch + [offset frame].pitch
[updated frame].yaw = [original frame].yaw + [offset frame].yaw

In getChainFK
[updated frame] = [offset frame] * [original frame]
```
There are two problems.
In ```updateURDF```, since rotation is not integrable, output URDF generated by ```updateURDF``` is different from the one used by optimizer with ```getChainFK```. 
In ```getChainFK```, since [offset frame] is applied from the left, [original frame].xyz is affected by [offset frame].rpy.

To avoid them, in this pull request, frames are calculated as
```
[updated frame] = [original frame] * [offset frame]
```
in both ```updateURDF``` and ```getChainFK```.