### PR TITLE
[WIP] Features: CheckeboardFinder circle board, add frames in kdl::Tree from yaml, more warning and error messages

### DIFF
--- a/robot_calibration/CMakeLists.txt
+++ b/robot_calibration/CMakeLists.txt
@@ -37,6 +37,7 @@ find_package(catkin REQUIRED
     std_msgs
     tf
     tf2_geometry_msgs
+    tf2_kdl
     tf2_ros
     visualization_msgs
 )
@@ -60,12 +61,14 @@ catkin_package(
     std_msgs
     tf
     tf2_geometry_msgs
+    tf2_kdl
     tf2_ros
   DEPENDS
     Boost
     orocos_kdl
   LIBRARIES
     robot_calibration
+    robot_calibration_feature_finders
 )
 
 if (CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)

--- a/robot_calibration/include/robot_calibration/capture/checkerboard_finder.h
+++ b/robot_calibration/include/robot_calibration/capture/checkerboard_finder.h
@@ -21,17 +21,17 @@
 #ifndef ROBOT_CALIBRATION_CAPTURE_CHECKERBOARD_FINDER_H
 #define ROBOT_CALIBRATION_CAPTURE_CHECKERBOARD_FINDER_H
 
-#include <ros/ros.h>
 #include <robot_calibration/capture/depth_camera.h>
 #include <robot_calibration/plugins/feature_finder.h>
 #include <robot_calibration_msgs/CalibrationData.h>
+#include <ros/ros.h>
 
 #include <opencv2/calib3d/calib3d.hpp>
+
 #include <cv_bridge/cv_bridge.h>
 
 namespace robot_calibration
 {
-
 /**
  *  \brief This class processes the point cloud input to find a checkerboard
  */
@@ -39,17 +39,27 @@ class CheckerboardFinder : public FeatureFinder
 {
 public:
   CheckerboardFinder();
-  bool init(const std::string& name, ros::NodeHandle & n);
-  bool find(robot_calibration_msgs::CalibrationData * msg);
+  bool init(const std::string& name, ros::NodeHandle& n);
+  bool find(robot_calibration_msgs::CalibrationData* msg);
 
 private:
-  bool findInternal(robot_calibration_msgs::CalibrationData * msg);
+  bool findInternal(robot_calibration_msgs::CalibrationData* msg);
 
   void cameraCallback(const sensor_msgs::PointCloud2& cloud);
   bool waitForCloud();
 
+  bool detectChessBoard(const cv::Mat_<cv::Vec3b>& image, std::vector<cv::Point2f>& points) const;
+  bool detectCircleBoard(const cv::Mat_<cv::Vec3b>& image, std::vector<cv::Point2f>& points,
+                         const bool asymmetric) const;
+
+  cv::Mat_<cv::Vec3b> getImageFromCloud() const;
+
+  std::vector<geometry_msgs::PointStamped> computeObjectPointsCircleBoard(const bool asymmetric) const;
+
+  std::vector<geometry_msgs::PointStamped> computeObjectPointsChessBoard() const;
+
   ros::Subscriber subscriber_;  /// Incoming sensor_msgs::PointCloud2
-  ros::Publisher publisher_;   /// Outgoing sensor_msgs::PointCloud2
+  ros::Publisher publisher_;    /// Outgoing sensor_msgs::PointCloud2
 
   bool waiting_;
   sensor_msgs::PointCloud2 cloud_;
@@ -58,17 +68,27 @@ private:
   /*
    * ROS Parameters
    */
-  int points_x_;        /// Size of checkerboard
-  int points_y_;        /// Size of checkerboard
+  int points_x_;  /// Size of checkerboard
+  int points_y_;  /// Size of checkerboard
 
-  double square_size_;     /// Size of a square on checkboard (in meters)
+  double square_size_;  /// Size of a square on checkboard (in meters)
 
-  bool output_debug_;   /// Should we output debug image/cloud?
+  bool output_debug_;  /// Should we output debug image/cloud?
 
-  std::string frame_id_;   /// Name of checkerboard frame
+  std::string frame_id_;  /// Name of checkerboard frame
 
   std::string camera_sensor_name_;
   std::string chain_sensor_name_;
+
+  int32_t trials_;
+
+  /**
+   * @brief Either "chess_board, circle_board_symmetric, circle_board_asymmetric"
+   */
+  static const std::string ChessBoard;
+  static const std::string CircleBoardSymmetric;
+  static const std::string CircleBoardAsymmetric;
+  std::string checkerboard_type_;
 };
 
 }  // namespace robot_calibration

--- a/robot_calibration/include/robot_calibration/ceres/chain3d_to_chain3d_error.h
+++ b/robot_calibration/include/robot_calibration/ceres/chain3d_to_chain3d_error.h
@@ -86,7 +86,10 @@ struct Chain3dToChain3d
     for (size_t i = 0; i < a_pts.size(); ++i)
     {
       if (a_pts[i].header.frame_id != b_pts[i].header.frame_id)
-        std::cerr << "Projected observation frame_ids do not match." << std::endl;
+      {
+        std::cerr << "Projected observation frame_ids do not match." << a_pts[i].header.frame_id
+                  << " != " << b_pts[i].header.frame_id << std::endl;
+      }
       residuals[(3*i)+0] = a_pts[i].point.x - b_pts[i].point.x;
       residuals[(3*i)+1] = a_pts[i].point.y - b_pts[i].point.y;
       residuals[(3*i)+2] = a_pts[i].point.z - b_pts[i].point.z;

--- a/robot_calibration/include/robot_calibration/ceres/optimization_params.h
+++ b/robot_calibration/include/robot_calibration/ceres/optimization_params.h
@@ -50,6 +50,15 @@ struct OptimizationParams
     double yaw;
   };
 
+  struct AdditionalFrame
+  {
+    XmlRpc::XmlRpcValue translation;
+    XmlRpc::XmlRpcValue rotation;
+
+    std::string name;
+    std::string parent;
+  };
+
   struct Params
   {
     std::string name;
@@ -63,6 +72,7 @@ struct OptimizationParams
   std::vector<FreeFrameInitialValue> free_frames_initial_values;
   std::vector<Params> models;
   std::vector<Params> error_blocks;
+  std::vector<AdditionalFrame> additional_frames;
 
   OptimizationParams();
   bool LoadFromROS(ros::NodeHandle& nh);

--- a/robot_calibration/include/robot_calibration/ceres/optimizer.h
+++ b/robot_calibration/include/robot_calibration/ceres/optimizer.h
@@ -66,7 +66,7 @@ public:
     return summary_;
   }
 
-  boost::shared_ptr<CalibrationOffsetParser> getOffsets()
+  boost::shared_ptr<CalibrationOffsetParser> getOffsets() const
   {
     return offsets_;
   }

--- a/robot_calibration/include/robot_calibration/load_bag.h
+++ b/robot_calibration/include/robot_calibration/load_bag.h
@@ -67,10 +67,20 @@ bool load_bag(const std::string& file_name,
 
   // Parse calibration_data topic
   rosbag::View data_view_(bag_, rosbag::TopicQuery("calibration_data"));
+  if (data_view_.size() < 1)
+  {
+    ROS_FATAL_STREAM("calibration_data topic not found in bag file.");
+    return false;
+  }
   BOOST_FOREACH (rosbag::MessageInstance const m, data_view_)
   {
     robot_calibration_msgs::CalibrationData::ConstPtr msg = m.instantiate<robot_calibration_msgs::CalibrationData>();
-    data.push_back(*msg);
+    if (msg->observations.empty())
+    {
+      ROS_ERROR_STREAM("observations is empty in calibration data sample");
+      return false;
+    }
+    data.push_back(*msg);    
   }
 
   return true;

--- a/robot_calibration/package.xml
+++ b/robot_calibration/package.xml
@@ -28,6 +28,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>tf2_kdl</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>visualization_msgs</build_depend>
   <build_depend>libceres-dev</build_depend>
@@ -52,6 +53,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>tf2_geometry_msgs</run_depend>
+  <run_depend>tf2_kdl</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>libceres-dev</run_depend>

--- a/robot_calibration/src/models.cpp
+++ b/robot_calibration/src/models.cpp
@@ -41,8 +41,13 @@ ChainModel::ChainModel(const std::string& name, KDL::Tree model, std::string roo
     root_(root), tip_(tip), name_(name)
 {
   // Create a KDL::Chain
-  if (!model.getChain(root, tip, chain_))
-    std::cerr << "Failed to get chain" << std::endl;
+  if (!model.getChain(root, tip, chain_)) 
+  {
+    std::stringstream ss;
+    ss << "Failed to get chain, root: " << root << " tip: " << tip << std::endl;
+    std::string msg = ss.str();
+    throw std::runtime_error(msg);
+  }
 }
 
 std::vector<geometry_msgs::PointStamped> ChainModel::project(
@@ -220,6 +225,14 @@ std::vector<geometry_msgs::PointStamped> Camera3dModel::project(
     double x = data.observations[sensor_idx].features[i].point.x;
     double y = data.observations[sensor_idx].features[i].point.y;
     double z = data.observations[sensor_idx].features[i].point.z;
+
+    if (std::fabs(z) < (static_cast<double>(10.0) * std::numeric_limits<double>::epsilon()))
+    {
+      ROS_WARN_STREAM("Z-value of sample point: ("
+                      << data.observations[sensor_idx].features[i].point << ") at observation at sensor index: "
+                      << sensor_idx << " and sample index: " << i << " is zero and will result in division by zero.");
+      continue;
+    }
 
     // Unproject through parameters stored at runtime
     double u = x * camera_fx / z + camera_cx;

--- a/robot_calibration/src/optimization_params.cpp
+++ b/robot_calibration/src/optimization_params.cpp
@@ -21,9 +21,7 @@
 
 namespace robot_calibration
 {
-
-OptimizationParams::OptimizationParams() :
-  base_link("base_link")
+OptimizationParams::OptimizationParams() : base_link("base_link")
 {
 }
 
@@ -39,10 +37,16 @@ bool OptimizationParams::LoadFromROS(ros::NodeHandle& nh)
     nh.getParam("free_params", names);
     ROS_ASSERT(names.getType() == XmlRpc::XmlRpcValue::TypeArray);
 
+    std::stringstream stream;
+    stream << "found the following free params:"<< std::endl;
+
     for (int i = 0; i < names.size(); ++i)
     {
       free_params.push_back(static_cast<std::string>(names[i]));
+      stream << "  - " << free_params.back() << std::endl;
     }
+
+    ROS_INFO_STREAM(stream.str());
   }
 
   if (nh.hasParam("free_frames"))
@@ -52,6 +56,9 @@ bool OptimizationParams::LoadFromROS(ros::NodeHandle& nh)
     XmlRpc::XmlRpcValue free_frame_params;
     nh.getParam("free_frames", free_frame_params);
     ROS_ASSERT(free_frame_params.getType() == XmlRpc::XmlRpcValue::TypeArray);
+
+    std::stringstream stream;
+    stream << "found the following free frames:"<< std::endl;
 
     for (int i = 0; i < free_frame_params.size(); ++i)
     {
@@ -64,7 +71,10 @@ bool OptimizationParams::LoadFromROS(ros::NodeHandle& nh)
       params.pitch = static_cast<bool>(free_frame_params[i]["pitch"]);
       params.yaw = static_cast<bool>(free_frame_params[i]["yaw"]);
       free_frames.push_back(params);
+      stream << "  - " <<  params.name << std::endl;
     }
+    ROS_INFO_STREAM(stream.str());
+
   }
 
   if (nh.hasParam("free_frames_initial_values"))
@@ -122,6 +132,25 @@ bool OptimizationParams::LoadFromROS(ros::NodeHandle& nh)
       params.type = static_cast<std::string>(error_params[i]["type"]);
       params.params = error_params[i];
       error_blocks.push_back(params);
+    }
+  }
+
+  if (nh.hasParam("additional_frames_in_tree"))
+  {
+    additional_frames.clear();
+
+    XmlRpc::XmlRpcValue frame_params;
+    nh.getParam("additional_frames_in_tree", frame_params);
+    ROS_ASSERT(frame_params.getType() == XmlRpc::XmlRpcValue::TypeArray);
+
+    for (int32_t i = 0; i < frame_params.size(); ++i)
+    {
+      AdditionalFrame frame;
+      frame.name = static_cast<std::string>(frame_params[i]["name"]);
+      frame.parent = static_cast<std::string>(frame_params[i]["parent"]);
+      frame.translation = frame_params[i]["translation"];
+      frame.rotation = frame_params[i]["rotation"];
+      additional_frames.push_back(frame);
     }
   }
 

--- a/robot_calibration/src/optimizer.cpp
+++ b/robot_calibration/src/optimizer.cpp
@@ -31,6 +31,9 @@
 #include <robot_calibration/ceres/outrageous_error.h>
 #include <robot_calibration/models/camera3d.h>
 #include <robot_calibration/models/chain.h>
+
+#include <tf2_kdl/tf2_kdl.h>
+
 #include <boost/shared_ptr.hpp>
 #include <string>
 #include <map>
@@ -38,9 +41,8 @@
 namespace robot_calibration
 {
 
-Optimizer::Optimizer(const std::string& robot_description) :
-  num_params_(0),
-  num_residuals_(0)
+Optimizer::Optimizer(const std::string &robot_description) : num_params_(0),
+                                                             num_residuals_(0)
 {
   if (!model_.initString(robot_description))
     std::cerr << "Failed to parse URDF." << std::endl;
@@ -53,7 +55,7 @@ Optimizer::~Optimizer()
 {
 }
 
-int Optimizer::optimize(OptimizationParams& params,
+int Optimizer::optimize(OptimizationParams &params,
                         std::vector<robot_calibration_msgs::CalibrationData> data,
                         bool progress_to_stdout)
 {
@@ -64,22 +66,71 @@ int Optimizer::optimize(OptimizationParams& params,
     return -1;
   }
 
+  std::stringstream      segments_out;
+  KDL::SegmentMap segments = tree_.getSegments();
+  segments_out << "Segment name in kdl tree: " << std::endl;
+  for (KDL::SegmentMap::iterator it = segments.begin(); it != segments.end(); it++)
+  {
+    segments_out << "  - " << it->first << std::endl;
+  }
+  ROS_INFO_STREAM(segments_out.str());
+
+  // Insert additional frames in KDL tree
+  ROS_INFO_STREAM("about to insert " << params.additional_frames.size() << " additional frames in tree");
+  for (size_t i = 0; i < params.additional_frames.size(); ++i)
+  {
+    // if frame is not already in tree
+    if (!segments.count(params.additional_frames[i].name))
+    {
+      KDL::Rotation rot = KDL::Rotation::Quaternion(
+          static_cast<double>(params.additional_frames[i].rotation[0]),
+          static_cast<double>(params.additional_frames[i].rotation[1]),
+          static_cast<double>(params.additional_frames[i].rotation[2]),
+          static_cast<double>(params.additional_frames[i].rotation[3]));
+      KDL::Vector trans(
+          static_cast<double>(params.additional_frames[i].translation[0]),
+          static_cast<double>(params.additional_frames[i].translation[1]),
+          static_cast<double>(params.additional_frames[i].translation[2]));
+      KDL::Frame frame(rot, trans);
+
+      if (tree_.addSegment(KDL::Segment(params.additional_frames[i].name,
+                                        KDL::Joint(KDL::Joint::None), frame),
+                           params.additional_frames[i].parent))
+      {
+        ROS_INFO_STREAM("added frame: "
+                        << params.additional_frames[i].name
+                        << " to parent: " << params.additional_frames[i].parent
+                        << " with transformation: " << tf2::kdlToTransform(frame).transform);
+      }
+      else
+      {
+        ROS_ERROR_STREAM("could not add frame: "
+                         << params.additional_frames[i].name
+                         << " to parent: " << params.additional_frames[i].parent
+                         << " with transformation: " << tf2::kdlToTransform(frame).transform);
+      }
+    }
+    else
+    {
+      ROS_WARN_STREAM("frame: "
+                      << params.additional_frames[i].name
+                      << " is already contained in tree");
+    }
+  }
+
   // Create models
   for (size_t i = 0; i < params.models.size(); ++i)
   {
     if (params.models[i].type == "chain")
     {
-      ROS_INFO_STREAM("Creating chain '" << params.models[i].name << "' from " <<
-                                            params.base_link << " to " <<
-                                            params.models[i].params["frame"]);
-      ChainModel* model = new ChainModel(params.models[i].name, tree_, params.base_link, params.models[i].params["frame"]);
+      ROS_INFO_STREAM("Creating chain '" << params.models[i].name << "' from " << params.base_link << " to " << params.models[i].params["frame"]);
+      ChainModel *model = new ChainModel(params.models[i].name, tree_, params.base_link, params.models[i].params["frame"]);
       models_[params.models[i].name] = model;
     }
     else if (params.models[i].type == "camera3d")
     {
-      ROS_INFO_STREAM("Creating camera3d '" << params.models[i].name << "' in frame " <<
-                                               params.models[i].params["frame"]);
-      Camera3dModel* model = new Camera3dModel(params.models[i].name, tree_, params.base_link, params.models[i].params["frame"]);
+      ROS_INFO_STREAM("Creating camera3d '" << params.models[i].name << "' from " << params.base_link << "' to " << params.models[i].params["frame"]);
+      Camera3dModel *model = new Camera3dModel(params.models[i].name, tree_, params.base_link, params.models[i].params["frame"]);
       models_[params.models[i].name] = model;
     }
     else
@@ -91,20 +142,41 @@ int Optimizer::optimize(OptimizationParams& params,
   // Reset which parameters are free (offset values are retained)
   offsets_->reset();
 
-  // Setup  parameters to calibrate
-  for (size_t i = 0; i < params.free_params.size(); ++i)
   {
-    offsets_->add(params.free_params[i]);
+    std::stringstream stream;
+    stream << "adding the following free params to the optimizer:" << std::endl;
+
+    // Setup  parameters to calibrate
+    for (size_t i = 0; i < params.free_params.size(); ++i)
+    {
+      offsets_->add(params.free_params[i]);
+      stream << "  - " << params.free_params[i] << std::endl;
+    }
+    ROS_INFO_STREAM(stream.str());
   }
-  for (size_t i = 0; i < params.free_frames.size(); ++i)
   {
-    offsets_->addFrame(params.free_frames[i].name,
-                       params.free_frames[i].x,
-                       params.free_frames[i].y,
-                       params.free_frames[i].z,
-                       params.free_frames[i].roll,
-                       params.free_frames[i].pitch,
-                       params.free_frames[i].yaw);
+    std::stringstream stream;
+    stream << "adding the following free frames to the optimizer:" << std::endl;
+    for (size_t i = 0; i < params.free_frames.size(); ++i)
+    {
+      bool found_joint = false;
+      for (KDL::SegmentMap::iterator it = segments.begin(); (it != segments.end()) && (!found_joint); it++)
+      {
+        if (it->second.segment.getJoint().getName() == params.free_frames[i].name)
+        {
+          found_joint = true;
+        }
+      }
+      if (!found_joint)
+      {
+        ROS_WARN_STREAM("frame: " << params.free_frames[i].name << " not found in KDL tree.");
+      }
+      offsets_->addFrame(params.free_frames[i].name, params.free_frames[i].x, params.free_frames[i].y,
+                         params.free_frames[i].z, params.free_frames[i].roll, params.free_frames[i].pitch,
+                         params.free_frames[i].yaw);
+      stream << "  - " << params.free_frames[i].name << std::endl;
+    }
+    ROS_INFO_STREAM(stream.str());
   }
   for (size_t i = 0; i < params.free_frames_initial_values.size(); ++i)
   {
@@ -116,17 +188,16 @@ int Optimizer::optimize(OptimizationParams& params,
                             params.free_frames_initial_values[i].pitch,
                             params.free_frames_initial_values[i].yaw))
     {
-      ROS_ERROR_STREAM("Error setting initial value for " <<
-                       params.free_frames_initial_values[i].name);
+      ROS_ERROR_STREAM("Error setting initial value for " << params.free_frames_initial_values[i].name);
     }
   }
 
   // Allocate space
-  double* free_params = new double[offsets_->size()];
+  double *free_params = new double[offsets_->size()];
   offsets_->initialize(free_params);
 
   // Houston, we have a problem...
-  ceres::Problem* problem = new ceres::Problem();
+  ceres::Problem *problem = new ceres::Problem();
 
   // For each sample of data:
   for (size_t i = 0; i < data.size(); ++i)
@@ -154,34 +225,42 @@ int Optimizer::optimize(OptimizationParams& params,
           continue;
 
         // Create the block
-        ceres::CostFunction * cost = Chain3dToChain3d::Create(models_[a_name],
-                                                              models_[b_name],
-                                                              offsets_.get(),
-                                                              data[i]);
+        ceres::CostFunction *cost = Chain3dToChain3d::Create(models_[a_name],
+                                                             models_[b_name],
+                                                             offsets_.get(),
+                                                             data[i]);
 
         // Output initial error
         if (progress_to_stdout)
         {
-          double ** params = new double*[1];
+          double **params = new double *[1];
           params[0] = free_params;
-          double * residuals = new double[cost->num_residuals()];
+          double *residuals = new double[cost->num_residuals()];
 
           cost->Evaluate(params, residuals, NULL);
 
-          std::cout << "INITIAL COST (" << i << ")" << std::endl << "  x: ";
+          std::cout << "INITIAL COST (" << i << ")" << std::endl
+                    << "  x: ";
           for (size_t k = 0; k < static_cast<size_t>(cost->num_residuals() / 3); ++k)
-            std::cout << "  " << std::setw(10) << std::fixed << residuals[(3*k + 0)];
-          std::cout << std::endl << "  y: ";
+            std::cout << "  " << std::setw(10) << std::fixed << residuals[(3 * k + 0)];
+          std::cout << std::endl
+                    << "  y: ";
           for (size_t k = 0; k < static_cast<size_t>(cost->num_residuals() / 3); ++k)
-            std::cout << "  " << std::setw(10) << std::fixed << residuals[(3*k + 1)];
-          std::cout << std::endl << "  z: ";
+            std::cout << "  " << std::setw(10) << std::fixed << residuals[(3 * k + 1)];
+          std::cout << std::endl
+                    << "  z: ";
           for (size_t k = 0; k < static_cast<size_t>(cost->num_residuals() / 3); ++k)
-            std::cout << "  " << std::setw(10) << std::fixed << residuals[(3*k + 2)];
-          std::cout << std::endl << std::endl;
+            std::cout << "  " << std::setw(10) << std::fixed << residuals[(3 * k + 2)];
+          std::cout << std::endl
+                    << std::endl;
+
+          
+          delete residuals;
+          delete params;          
         }
 
         problem->AddResidualBlock(cost,
-                                  NULL,  // squared loss
+                                  NULL, // squared loss
                                   free_params);
       }
       else if (params.error_blocks[j].type == "chain3d_to_plane")
@@ -201,29 +280,33 @@ int Optimizer::optimize(OptimizationParams& params,
           continue;
 
         // Create the block
-        ceres::CostFunction * cost =
-          Chain3dToPlane::Create(models_[chain_name],
-                                 offsets_.get(),
-                                 data[i],
-                                 params.getParam(params.error_blocks[j], "a", 0.0),
-                                 params.getParam(params.error_blocks[j], "b", 0.0),
-                                 params.getParam(params.error_blocks[j], "c", 1.0),
-                                 params.getParam(params.error_blocks[j], "d", 0.0),
-                                 params.getParam(params.error_blocks[j], "scale", 1.0));
+        ceres::CostFunction *cost =
+            Chain3dToPlane::Create(models_[chain_name],
+                                   offsets_.get(),
+                                   data[i],
+                                   params.getParam(params.error_blocks[j], "a", 0.0),
+                                   params.getParam(params.error_blocks[j], "b", 0.0),
+                                   params.getParam(params.error_blocks[j], "c", 1.0),
+                                   params.getParam(params.error_blocks[j], "d", 0.0),
+                                   params.getParam(params.error_blocks[j], "scale", 1.0));
 
         // Output initial error
         if (progress_to_stdout)
         {
-          double ** params = new double*[1];
+          double **params = new double *[1];
           params[0] = free_params;
-          double * residuals = new double[cost->num_residuals()];
+          double *residuals = new double[cost->num_residuals()];
 
           cost->Evaluate(params, residuals, NULL);
 
-          std::cout << "INITIAL COST (" << i << ")" << std::endl << "  d: ";
+          std::cout << "INITIAL COST (" << i << ")" << std::endl
+                    << "  d: ";
           for (size_t k = 0; k < static_cast<size_t>(cost->num_residuals()); ++k)
             std::cout << "  " << std::setw(10) << std::fixed << residuals[(k)];
-          std::cout << std::endl << std::endl;
+          std::cout << std::endl
+                    << std::endl;
+          delete residuals;
+          delete params;
         }
 
         problem->AddResidualBlock(cost,
@@ -250,48 +333,56 @@ int Optimizer::optimize(OptimizationParams& params,
           continue;
 
         // Create the block
-        ceres::CostFunction * cost =
-          PlaneToPlaneError::Create(models_[a_name],
-                                    models_[b_name],
-                                    offsets_.get(),
-                                    data[i],
-                                    params.getParam(params.error_blocks[j], "scale_normal", 1.0),
-                                    params.getParam(params.error_blocks[j], "scale_offset", 1.0));
+        ceres::CostFunction *cost =
+            PlaneToPlaneError::Create(models_[a_name],
+                                      models_[b_name],
+                                      offsets_.get(),
+                                      data[i],
+                                      params.getParam(params.error_blocks[j], "scale_normal", 1.0),
+                                      params.getParam(params.error_blocks[j], "scale_offset", 1.0));
 
         // Output initial error
         if (progress_to_stdout)
         {
-          double ** params = new double*[1];
+          double **params = new double *[1];
           params[0] = free_params;
-          double * residuals = new double[cost->num_residuals()];
+          double *residuals = new double[cost->num_residuals()];
 
           cost->Evaluate(params, residuals, NULL);
-          std::cout << "INITIAL COST (" << i << ")" << std::endl << "  a: ";
+          std::cout << "INITIAL COST (" << i << ")" << std::endl
+                    << "  a: ";
           std::cout << "  " << std::setw(10) << std::fixed << residuals[0];
-          std::cout << std::endl << "  b: ";
+          std::cout << std::endl
+                    << "  b: ";
           std::cout << "  " << std::setw(10) << std::fixed << residuals[1];
-          std::cout << std::endl << "  c: ";
+          std::cout << std::endl
+                    << "  c: ";
           std::cout << "  " << std::setw(10) << std::fixed << residuals[2];
-          std::cout << std::endl << "  d: ";
+          std::cout << std::endl
+                    << "  d: ";
           std::cout << "  " << std::setw(10) << std::fixed << residuals[3];
-          std::cout << std::endl << std::endl;
+          std::cout << std::endl
+                    << std::endl;
+
+          delete residuals;
+          delete params;          
         }
 
         problem->AddResidualBlock(cost,
-                                  NULL,  // squared loss
+                                  NULL, // squared loss
                                   free_params);
       }
       else if (params.error_blocks[j].type == "outrageous")
       {
         // Outrageous error block requires no particular sensors, add to every sample
         problem->AddResidualBlock(
-          OutrageousError::Create(offsets_.get(),
-                                  static_cast<std::string>(params.error_blocks[j].params["param"]),
-                                  params.getParam(params.error_blocks[j], "joint_scale", 1.0),
-                                  params.getParam(params.error_blocks[j], "position_scale", 1.0),
-                                  params.getParam(params.error_blocks[j], "rotation_scale", 1.0)),
-          NULL, // squared loss
-          free_params);
+            OutrageousError::Create(offsets_.get(),
+                                    static_cast<std::string>(params.error_blocks[j].params["param"]),
+                                    params.getParam(params.error_blocks[j], "joint_scale", 1.0),
+                                    params.getParam(params.error_blocks[j], "position_scale", 1.0),
+                                    params.getParam(params.error_blocks[j], "rotation_scale", 1.0)),
+            NULL, // squared loss
+            free_params);
       }
       else
       {
@@ -315,7 +406,8 @@ int Optimizer::optimize(OptimizationParams& params,
   summary_.reset(new ceres::Solver::Summary());
   ceres::Solve(options, problem, summary_.get());
   if (progress_to_stdout)
-    std::cout << "\n" << summary_->BriefReport() << std::endl;
+    std::cout << "\n"
+              << summary_->BriefReport() << std::endl;
 
   // Save some status
   num_params_ = problem->NumParameters();
@@ -331,4 +423,4 @@ int Optimizer::optimize(OptimizationParams& params,
   return 0;
 }
 
-}  // namespace robot_calibration
+} // namespace robot_calibration


### PR DESCRIPTION
Hey, I've made some extensions that are relevant to us:

1. CheckerBoard finder support for [(a)symmetric circle boards](https://nerian.com/support/resources/patterns/).
2. Adding frames in KDL tree that are not defined in the``` robot_description```. This is helpful when using a realsense or other hardware that publishes tf frames that should be contained in the kinematic chain but are not defined in the urdf.
3. Some more warnings, errors and critical logs indicating invalid configurations.
4. More control over the output folder.

I consider this WIP but I wanted to ask if these additions might be of interest.

I also have an implementation of a chessboard and circle board finder that detects features directly in rgb images without depth information. The depth is computed using the [Perspective-N-Point ](https://en.wikipedia.org/wiki/Perspective-n-Point) algorithm (OpenCV). 
This is not included in this PR but also here the question if this might be of interest.