### PR TITLE
Updates "Press key when arm is ready..." message

### DIFF
--- a/robot_calibration/src/calibrate.cpp
+++ b/robot_calibration/src/calibrate.cpp
@@ -170,7 +170,7 @@ int main(int argc, char** argv)
       if (poses.size() == 0)
       {
         // Manual calibration, wait for keypress
-        ROS_INFO("Press key when arm is ready... (type 'done' to finish capture)");
+        ROS_INFO("Press [Enter] to capture a sample... (or type 'done' and [Enter] to finish capture)");
         std::string throwaway;
         std::getline(std::cin, throwaway);
         if (throwaway.compare("done") == 0)


### PR DESCRIPTION
Updates "Press key when arm is ready..." with "Press [Enter] to capture a sample..." message to avoid confusion when not doing arm calibration.

( addresses #104 )

I considered still asking for "the robot to be static" before sampling, but code already calls `waitToSettle()` before sampling, and I thought asking for the robot to become static might make people think that the robot is supposed to move before sampling which may not be necessary in all cases.

Let me know if the wording is reasonable.