### PR TITLE
add robot finder

### DIFF
--- a/robot_calibration/CMakeLists.txt
+++ b/robot_calibration/CMakeLists.txt
@@ -106,7 +106,8 @@ add_dependencies(robot_calibration robot_calibration_msgs_generate_messages_cpp)
 
 add_library(robot_calibration_feature_finders src/finders/checkerboard_finder.cpp
                                               src/finders/led_finder.cpp
-                                              src/finders/plane_finder.cpp)
+                                              src/finders/plane_finder.cpp
+                                              src/finders/robot_finder.cpp)
 target_link_libraries(robot_calibration_feature_finders robot_calibration
                                                         ${Boost_LIBRARIES}
                                                         ${catkin_LIBRARIES}

--- a/robot_calibration/include/robot_calibration/capture/robot_finder.h
+++ b/robot_calibration/include/robot_calibration/capture/robot_finder.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Michael Ferguson
+ * Copyright (C) 2014-2017 Fetch Robotics Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ROBOT_CALIBRATION_CAPTURE_ROBOT_FINDER_H
+#define ROBOT_CALIBRATION_CAPTURE_ROBOT_FINDER_H
+
+#include <ros/ros.h>
+#include <robot_calibration/capture/plane_finder.h>
+
+namespace robot_calibration
+{
+
+class RobotFinder : public PlaneFinder
+{
+public:
+  RobotFinder();
+  virtual ~RobotFinder() = default;
+  virtual bool init(const std::string& name, ros::NodeHandle & n);
+  virtual bool find(robot_calibration_msgs::CalibrationData * msg);
+
+protected:
+  // Observation name for robot points
+  std::string robot_sensor_name_;
+
+  // Publisher for robot points debugging
+  ros::Publisher robot_publisher_;
+
+  double min_robot_x_;
+  double max_robot_x_;
+  double min_robot_y_;
+  double max_robot_y_;
+  double min_robot_z_;
+  double max_robot_z_;
+};
+
+}  // namespace robot_calibration
+
+#endif  // ROBOT_CALIBRATION_CAPTURE_ROBOT_FINDER_H

--- a/robot_calibration/robot_calibration.xml
+++ b/robot_calibration/robot_calibration.xml
@@ -18,4 +18,10 @@
     <description>Feature finder that detects points corresponding to planes.</description>
   </class>
 
+  <class name="robot_calibration/RobotFinder"
+         type="robot_calibration::RobotFinder"
+         base_class_type="robot_calibration::FeatureFinder">
+    <description>Feature finder that detects points corresponding to the ground plane and the robot.</description>
+  </class>
+
 </library>

--- a/robot_calibration/src/finders/robot_finder.cpp
+++ b/robot_calibration/src/finders/robot_finder.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2018-2022 Michael Ferguson
+ * Copyright (C) 2015-2017 Fetch Robotics Inc.
+ * Copyright (C) 2013-2014 Unbounded Robotics Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Author: Niharika Arora, Michael Ferguson
+
+#include <math.h>
+#include <pluginlib/class_list_macros.h>
+#include <robot_calibration/capture/robot_finder.h>
+#include <sensor_msgs/point_cloud2_iterator.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+PLUGINLIB_EXPORT_CLASS(robot_calibration::RobotFinder, robot_calibration::FeatureFinder)
+
+namespace robot_calibration
+{
+
+const unsigned X = 0;
+const unsigned Y = 1;
+const unsigned Z = 2;
+
+RobotFinder::RobotFinder() :
+  PlaneFinder()
+{
+}
+
+bool RobotFinder::init(const std::string& name,
+                       ros::NodeHandle & nh)
+{
+  if (!PlaneFinder::init(name, nh))
+    return false;
+
+  // Name of the sensor model that will be used during optimization
+  nh.param<std::string>("robot_sensor_name", robot_sensor_name_, "camera_robot");
+
+  // Publish the observation as a PointCloud2
+  robot_publisher_ = nh.advertise<sensor_msgs::PointCloud2>(getName() + "_robot_points", 10);
+
+  // Valid points must lie within this box, in the transform_frame
+  nh.param<double>("min_robot_x", min_robot_x_, -2.0);
+  nh.param<double>("max_robot_x", max_robot_x_, 2.0);
+  nh.param<double>("min_robot_y", min_robot_y_, -2.0);
+  nh.param<double>("max_robot_y", max_robot_y_, 2.0);
+  nh.param<double>("min_robot_z", min_robot_z_, 0.0);
+  nh.param<double>("max_robot_z", max_robot_z_, 2.0);
+
+  return true;
+}
+
+bool RobotFinder::find(robot_calibration_msgs::CalibrationData * msg)
+{
+  if (!waitForCloud())
+  {
+    ROS_ERROR("No point cloud data");
+    return false;
+  }
+
+  // Remove invalid points
+  removeInvalidPoints(cloud_, min_x_, max_x_, min_y_, max_y_, min_z_, max_z_);
+
+  // Find the ground plane and extract it
+  sensor_msgs::PointCloud2 plane = extractPlane(cloud_);
+
+  // Remove anything that isn't the robot from the cloud
+  removeInvalidPoints(cloud_, min_robot_x_, max_robot_x_, min_robot_y_,
+                      max_robot_y_, min_robot_z_, max_robot_z_);
+
+  // Pull out both sets of observations
+  extractObservation(plane_sensor_name_, plane, msg, &publisher_);
+  extractObservation(robot_sensor_name_, cloud_, msg, &robot_publisher_);
+
+  // Report success
+  return true;
+}
+
+}  // namespace robot_calibration


### PR DESCRIPTION
The robot finder can be used to find the base of the robot and the floor at the same time