### PR TITLE
allow using the same camera model with different finders

### DIFF
--- a/robot_calibration/include/robot_calibration/models/camera3d.h
+++ b/robot_calibration/include/robot_calibration/models/camera3d.h
@@ -33,12 +33,14 @@ class Camera3dModel : public ChainModel
 public:
   /**
    *  \brief Create a new camera 3d model (Kinect/Primesense).
+   *  \param name The name for this sensor, will be be used to select observations
+   *  \param param_name The name to use when finding camera parameters, often the same as name
    *  \param model The KDL model of the robot's kinematics.
    *  \param root The name of the root link, must be consistent across all
    *         models used for error modeling. Usually 'base_link'.
    *  \param tip The tip of the chain.
    */
-  Camera3dModel(const std::string& name, KDL::Tree model, std::string root, std::string tip);
+  Camera3dModel(const std::string& name, const std::string& param_name, KDL::Tree model, std::string root, std::string tip);
   virtual ~Camera3dModel() {}
 
   /**
@@ -47,6 +49,9 @@ public:
   virtual std::vector<geometry_msgs::PointStamped> project(
     const robot_calibration_msgs::CalibrationData& data,
     const CalibrationOffsetParser& offsets);
+
+protected:
+  std::string param_name_;
 };
 
 }  // namespace robot_calibration

--- a/robot_calibration/src/models.cpp
+++ b/robot_calibration/src/models.cpp
@@ -149,8 +149,9 @@ KDL::Frame ChainModel::getChainFK(const CalibrationOffsetParser& offsets,
   return p_out;
 }
 
-Camera3dModel::Camera3dModel(const std::string& name, KDL::Tree model, std::string root, std::string tip) :
-    ChainModel(name, model, root, tip)
+Camera3dModel::Camera3dModel(const std::string& name, const std::string& param_name, KDL::Tree model, std::string root, std::string tip) :
+    ChainModel(name, model, root, tip),
+    param_name_(param_name)
 {
   // TODO add additional parameters for unprojecting observations using initial parameters
 }
@@ -207,12 +208,12 @@ std::vector<geometry_msgs::PointStamped> Camera3dModel::project(
   }
 
   // Get calibrated camera info
-  double new_camera_fx = camera_fx * (1.0 + offsets.get(name_+"_fx"));
-  double new_camera_fy = camera_fy * (1.0 + offsets.get(name_+"_fy"));
-  double new_camera_cx = camera_cx * (1.0 + offsets.get(name_+"_cx"));
-  double new_camera_cy = camera_cy * (1.0 + offsets.get(name_+"_cy"));
-  double new_z_offset = offsets.get(name_+"_z_offset");
-  double new_z_scaling = 1.0 + offsets.get(name_+"_z_scaling");
+  double new_camera_fx = camera_fx * (1.0 + offsets.get(param_name_ + "_fx"));
+  double new_camera_fy = camera_fy * (1.0 + offsets.get(param_name_ + "_fy"));
+  double new_camera_cx = camera_cx * (1.0 + offsets.get(param_name_ + "_cx"));
+  double new_camera_cy = camera_cy * (1.0 + offsets.get(param_name_ + "_cy"));
+  double new_z_offset = offsets.get(param_name_ + "_z_offset");
+  double new_z_scaling = 1.0 + offsets.get(param_name_ + "_z_scaling");
 
   points.resize(data.observations[sensor_idx].features.size());
 

--- a/robot_calibration/src/optimizer.cpp
+++ b/robot_calibration/src/optimizer.cpp
@@ -79,7 +79,13 @@ int Optimizer::optimize(OptimizationParams& params,
     {
       ROS_INFO_STREAM("Creating camera3d '" << params.models[i].name << "' in frame " <<
                                                params.models[i].params["frame"]);
-      Camera3dModel* model = new Camera3dModel(params.models[i].name, tree_, params.base_link, params.models[i].params["frame"]);
+      std::string param_name = params.models[i].params["param_name"];
+      if (param_name == "")
+      {
+        // Default to same name as sensor
+        param_name = params.models[i].name;
+      }
+      Camera3dModel* model = new Camera3dModel(params.models[i].name, param_name, tree_, params.base_link, params.models[i].params["frame"]);
       models_[params.models[i].name] = model;
     }
     else

--- a/robot_calibration/src/tools/viz.cpp
+++ b/robot_calibration/src/tools/viz.cpp
@@ -103,7 +103,13 @@ int main(int argc, char** argv)
     {
       ROS_INFO_STREAM("Creating camera3d '" << params.models[i].name << "' in frame " <<
                                                params.models[i].params["frame"]);
-      robot_calibration::Camera3dModel* model = new robot_calibration::Camera3dModel(params.models[i].name, tree, params.base_link, params.models[i].params["frame"]);
+      std::string param_name = params.models[i].params["param_name"];
+      if (param_name == "")
+      {
+        // Default to same name as sensor
+        param_name = params.models[i].name;
+      }
+      robot_calibration::Camera3dModel* model = new robot_calibration::Camera3dModel(params.models[i].name, param_name, tree, params.base_link, params.models[i].params["frame"]);
       models[params.models[i].name] = model;
       model_names.push_back(params.models[i].name);
       camera_pubs[params.models[i].name] = nh.advertise<sensor_msgs::PointCloud2>(params.models[i].name, 1);

--- a/robot_calibration/test/chain_model_tests.cpp
+++ b/robot_calibration/test/chain_model_tests.cpp
@@ -77,12 +77,12 @@ TEST(Camera3dModelTests, BadChainThrows)
   ASSERT_TRUE(kdl_parser::treeFromString(robot_description, tree));
 
   ASSERT_NO_THROW(
-      { auto uut = Camera3dModel("uut", tree, "link_0", "link_3"); });
+      { auto uut = Camera3dModel("uut", "uut", tree, "link_0", "link_3"); });
 
-  ASSERT_THROW({ auto uut = Camera3dModel("uut", tree, "link_99", "link_3"); },
+  ASSERT_THROW({ auto uut = Camera3dModel("uut", "uut", tree, "link_99", "link_3"); },
                std::runtime_error);
 
-  ASSERT_THROW({ auto uut = Camera3dModel("uut", tree, "link_0", "link_99"); },
+  ASSERT_THROW({ auto uut = Camera3dModel("uut", "uut", tree, "link_0", "link_99"); },
                std::runtime_error);
 }
 


### PR DESCRIPTION
the use case here is that a single camera is used in multiple
finders. When that happens we want the same parameters to
be used when calibrating the camera intrinsics, but we
need a different camera name to differentiate which
observation should be associated with which error block
(this is especially true for the upcoming robot/plane
finder)