### PR TITLE
sample observation more evenly

### DIFF
--- a/robot_calibration/include/robot_calibration/capture/plane_finder.h
+++ b/robot_calibration/include/robot_calibration/capture/plane_finder.h
@@ -27,7 +27,9 @@
 
 namespace robot_calibration
 {
-
+/**
+ * @brief Finds the largest plane in a point cloud.
+ */
 class PlaneFinder : public FeatureFinder
 {
 public:
@@ -91,6 +93,7 @@ protected:
 
   std::string plane_sensor_name_;
   int points_max_;
+  double initial_sampling_distance_;
   double plane_tolerance_;
   double min_x_;
   double max_x_;

--- a/robot_calibration/src/finders/plane_finder.cpp
+++ b/robot_calibration/src/finders/plane_finder.cpp
@@ -61,6 +61,9 @@ bool PlaneFinder::init(const std::string& name,
   // Maximum number of valid points to include in the observation
   nh.param<int>("points_max", points_max_, 60);
 
+  // When downsampling cloud, start by selecting points at least this far apart
+  nh.param<double>("initial_sample_distance", initial_sampling_distance_, 0.2);
+
   // Maximum distance from plane that point can be located
   nh.param<double>("tolerance", plane_tolerance_, 0.02);
 
@@ -319,6 +322,57 @@ sensor_msgs::PointCloud2 PlaneFinder::extractPlane(sensor_msgs::PointCloud2& clo
   return plane_cloud;
 }
 
+int sampleCloud(const sensor_msgs::PointCloud2& points,
+                double sample_distance, size_t max_points,
+                std::vector<geometry_msgs::PointStamped>& sampled_points)
+{
+  // Square distance for efficiency
+  double max_dist_sq = sample_distance * sample_distance;
+
+  // Iterate through cloud
+  sensor_msgs::PointCloud2ConstIterator<float> points_iter(points, "x");
+  for (size_t i = 0; i < points.width; ++i)
+  {
+    // Get (untransformed) 3d point
+    geometry_msgs::PointStamped rgbd;
+    rgbd.point.x = (points_iter + i)[X];
+    rgbd.point.y = (points_iter + i)[Y];
+    rgbd.point.z = (points_iter + i)[Z];
+
+    // Is this far enough from our current points?
+    bool include_point = true;
+    for (auto point : sampled_points)
+    {
+      double dx = point.point.x - rgbd.point.x;
+      double dy = point.point.y - rgbd.point.y;
+      double dz = point.point.z - rgbd.point.z;
+
+      double dist = dx * dx + dy * dy + dz * dz;
+      if (dist < max_dist_sq)
+      {
+        include_point = false;
+        break;
+      }
+    }
+
+    if (include_point)
+    {
+      // Add this to samples
+      sampled_points.push_back(rgbd);
+    }
+
+    if (sampled_points.size() >= max_points)
+    {
+      // Done sampling
+      break;
+    }
+  }
+
+  ROS_INFO("Extracted %lu points with sampling distance of %f", sampled_points.size(), sample_distance);
+
+  return sampled_points.size();
+}
+
 void PlaneFinder::extractObservation(const std::string& sensor_name,
                                      const sensor_msgs::PointCloud2& cloud,
                                      robot_calibration_msgs::CalibrationData * msg,
@@ -350,19 +404,20 @@ void PlaneFinder::extractObservation(const std::string& sensor_name,
   msg->observations[idx_cam].sensor_name = sensor_name;
   msg->observations[idx_cam].ext_camera_info = depth_camera_manager_.getDepthCameraInfo();
 
+  // Get observation points
+  std::vector<geometry_msgs::PointStamped> sampled_points;
+  double sample_distance = initial_sampling_distance_;
+  while (sampled_points.size() < points_total)
+  {
+    sampleCloud(cloud, sample_distance, points_total, sampled_points);
+    sample_distance /= 2;
+  }
+
   // Fill in observation
-  size_t step = cloud.width / points_total;
-  size_t index = step / 2;
   sensor_msgs::PointCloud2Iterator<float> viz_cloud_iter(viz_cloud, "x");
   sensor_msgs::PointCloud2ConstIterator<float> xyz(cloud, "x");
-  for (size_t i = 0; index < cloud.width && i < points_total; ++i)
+  for (auto rgbd : sampled_points)
   {
-    // Get (untransformed) 3d point
-    geometry_msgs::PointStamped rgbd;
-    rgbd.point.x = (xyz + index)[X];
-    rgbd.point.y = (xyz + index)[Y];
-    rgbd.point.z = (xyz + index)[Z];
-
     // Add to observation
     msg->observations[idx_cam].features.push_back(rgbd);
 
@@ -371,9 +426,6 @@ void PlaneFinder::extractObservation(const std::string& sensor_name,
     viz_cloud_iter[1] = rgbd.point.y;
     viz_cloud_iter[2] = rgbd.point.z;
     ++viz_cloud_iter;
-
-    // Next point
-    index += step;
   }
 
   // Add debug cloud to message


### PR DESCRIPTION
the plane finder previously took points that were equally distributed by
point cloud index - however this doesn't actually always represent a
point cloud that is geometry well distributed. change the sampling so
that we make one or more passes through the cloud sampling points that
are at least a minimum distance away from the already sampled points