### PR TITLE
Add finder for 2d checkerboard

### DIFF
--- a/robot_calibration/include/robot_calibration/finders/checkerboard_finder.hpp
+++ b/robot_calibration/include/robot_calibration/finders/checkerboard_finder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Michael Ferguson
+ * Copyright (C) 2018-2023 Michael Ferguson
  * Copyright (C) 2015 Fetch Robotics Inc.
  * Copyright (C) 2013-2014 Unbounded Robotics Inc.
  *
@@ -33,8 +33,9 @@ namespace robot_calibration
 {
 
 /**
- *  \brief This class processes the point cloud input to find a checkerboard
+ *  \brief Finds checkerboards in images or point clouds
  */
+template <typename T>
 class CheckerboardFinder : public FeatureFinder
 {
 public:
@@ -46,16 +47,18 @@ public:
 
 private:
   bool findInternal(robot_calibration_msgs::msg::CalibrationData * msg);
+  bool findCheckerboardPoints(sensor_msgs::msg::Image::SharedPtr image,
+                              std::vector<cv::Point2f>& points);
 
-  void cameraCallback(sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud);
-  bool waitForCloud();
+  void cameraCallback(typename T::ConstSharedPtr cloud);
+  bool waitForMsg();
 
-  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr subscriber_;
+  typename rclcpp::Subscription<T>::SharedPtr subscriber_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr publisher_;
   rclcpp::Clock::SharedPtr clock_;
 
   bool waiting_;
-  sensor_msgs::msg::PointCloud2 cloud_;
+  T msg_;
   DepthCameraInfoManager depth_camera_manager_;
 
   /*

--- a/robot_calibration/include/robot_calibration/finders/checkerboard_finder.hpp
+++ b/robot_calibration/include/robot_calibration/finders/checkerboard_finder.hpp
@@ -47,7 +47,7 @@ public:
 
 private:
   bool findInternal(robot_calibration_msgs::msg::CalibrationData * msg);
-  bool findCheckerboardPoints(sensor_msgs::msg::Image::SharedPtr image,
+  bool findCheckerboardPoints(sensor_msgs::msg::Image::ConstSharedPtr image,
                               std::vector<cv::Point2f>& points);
 
   void cameraCallback(typename T::ConstSharedPtr cloud);
@@ -58,7 +58,7 @@ private:
   rclcpp::Clock::SharedPtr clock_;
 
   bool waiting_;
-  T msg_;
+  typename T::ConstSharedPtr msg_;
   DepthCameraInfoManager depth_camera_manager_;
 
   /*

--- a/robot_calibration/robot_calibration.xml
+++ b/robot_calibration/robot_calibration.xml
@@ -3,7 +3,13 @@
   <class name="robot_calibration::CheckerboardFinder"
          type="robot_calibration::CheckerboardFinder<sensor_msgs::msg::PointCloud2>"
          base_class_type="robot_calibration::FeatureFinder">
-    <description>Feature finder that detect checkerboards.</description>
+    <description>Feature finder that detect checkerboards in point clouds.</description>
+  </class>
+
+  <class name="robot_calibration::CheckerboardFinder2d"
+         type="robot_calibration::CheckerboardFinder<sensor_msgs::msg::Image>"
+         base_class_type="robot_calibration::FeatureFinder">
+    <description>Feature finder that detect checkerboards in 2d images.</description>
   </class>
 
   <class type="robot_calibration::LedFinder"

--- a/robot_calibration/robot_calibration.xml
+++ b/robot_calibration/robot_calibration.xml
@@ -1,6 +1,7 @@
 <library path="robot_calibration_feature_finders">
 
-  <class type="robot_calibration::CheckerboardFinder"
+  <class name="robot_calibration::CheckerboardFinder"
+         type="robot_calibration::CheckerboardFinder<sensor_msgs::msg::PointCloud2>"
          base_class_type="robot_calibration::FeatureFinder">
     <description>Feature finder that detect checkerboards.</description>
   </class>

--- a/robot_calibration/src/finders/checkerboard_finder.cpp
+++ b/robot_calibration/src/finders/checkerboard_finder.cpp
@@ -31,14 +31,16 @@ const unsigned X = 0;
 const unsigned Y = 1;
 const unsigned Z = 2;
 
-CheckerboardFinder::CheckerboardFinder() :
+template <typename T>
+CheckerboardFinder<T>::CheckerboardFinder() :
   waiting_(false)
 {
 }
 
-bool CheckerboardFinder::init(const std::string& name,
-                              std::shared_ptr<tf2_ros::Buffer> buffer,
-                              rclcpp::Node::SharedPtr node)
+template <typename T>
+bool CheckerboardFinder<T>::init(const std::string& name,
+                                 std::shared_ptr<tf2_ros::Buffer> buffer,
+                                 rclcpp::Node::SharedPtr node)
 {
   if (!FeatureFinder::init(name, buffer, node))
   {
@@ -50,7 +52,7 @@ bool CheckerboardFinder::init(const std::string& name,
   // Setup subscriber
   std::string topic_name;
   topic_name = node->declare_parameter<std::string>(name + ".topic", name + "/points");
-  subscriber_ = node->create_subscription<sensor_msgs::msg::PointCloud2>(
+  subscriber_ = node->create_subscription<T>(
     topic_name,
     rclcpp::QoS(1).best_effort().keep_last(1),
     std::bind(&CheckerboardFinder::cameraCallback, this, std::placeholders::_1));
@@ -87,17 +89,19 @@ bool CheckerboardFinder::init(const std::string& name,
   return true;
 }
 
-void CheckerboardFinder::cameraCallback(sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud)
+template <typename T>
+void CheckerboardFinder<T>::cameraCallback(typename T::ConstSharedPtr msg)
 {
   if (waiting_)
   {
-    cloud_ = *cloud;
+    msg_ = *msg;
     waiting_ = false;
   }
 }
 
 // Returns true if we got a message, false if we timeout
-bool CheckerboardFinder::waitForCloud()
+template <typename T>
+bool CheckerboardFinder<T>::waitForMsg()
 {
   // Stored as weak pointer, need to grab a real shared pointer
   auto node = node_ptr_.lock();
@@ -122,11 +126,12 @@ bool CheckerboardFinder::waitForCloud()
     rclcpp::sleep_for(std::chrono::milliseconds(10));
     rclcpp::spin_some(node);
   }
-  RCLCPP_ERROR(LOGGER, "Failed to get cloud");
+  RCLCPP_ERROR(LOGGER, "Failed to get message");
   return !waiting_;
 }
 
-bool CheckerboardFinder::find(robot_calibration_msgs::msg::CalibrationData * msg)
+template <typename T>
+bool CheckerboardFinder<T>::find(robot_calibration_msgs::msg::CalibrationData * msg)
 {
   // Try up to 50 frames
   for (int i = 0; i < 50; ++i)
@@ -142,19 +147,20 @@ bool CheckerboardFinder::find(robot_calibration_msgs::msg::CalibrationData * msg
   return false;
 }
 
-bool CheckerboardFinder::findInternal(robot_calibration_msgs::msg::CalibrationData * msg)
+template <>
+bool CheckerboardFinder<sensor_msgs::msg::PointCloud2>::findInternal(robot_calibration_msgs::msg::CalibrationData * msg)
 {
   geometry_msgs::msg::PointStamped rgbd;
   geometry_msgs::msg::PointStamped world;
 
   // Get cloud
-  if (!waitForCloud())
+  if (!waitForMsg())
   {
     RCLCPP_ERROR(LOGGER, "No point cloud data");
     return false;
   }
 
-  if (cloud_.height == 1)
+  if (msg_.height == 1)
   {
     RCLCPP_ERROR(LOGGER, "OpenCV does not support unorganized cloud/image.");
     return false;
@@ -162,15 +168,15 @@ bool CheckerboardFinder::findInternal(robot_calibration_msgs::msg::CalibrationDa
 
   // Get an image message from point cloud
   sensor_msgs::msg::Image::SharedPtr image_msg(new sensor_msgs::msg::Image);
-  sensor_msgs::PointCloud2ConstIterator<uint8_t> rgb(cloud_, "rgb");
+  sensor_msgs::PointCloud2ConstIterator<uint8_t> rgb(msg_, "rgb");
   image_msg->encoding = "bgr8";
-  image_msg->height = cloud_.height;
-  image_msg->width = cloud_.width;
+  image_msg->height = msg_.height;
+  image_msg->width = msg_.width;
   image_msg->step = image_msg->width * sizeof (uint8_t) * 3;
   image_msg->data.resize(image_msg->step * image_msg->height);
-  for (size_t y = 0; y < cloud_.height; y++)
+  for (size_t y = 0; y < msg_.height; y++)
   {
-    for (size_t x = 0; x < cloud_.width; x++)
+    for (size_t x = 0; x < msg_.width; x++)
     {
       uint8_t* pixel = &(image_msg->data[y * image_msg->step + x * 3]);
       pixel[0] = rgb[0];
@@ -180,26 +186,8 @@ bool CheckerboardFinder::findInternal(robot_calibration_msgs::msg::CalibrationDa
     }
   }
 
-  // Get an OpenCV image from the cloud
-  cv_bridge::CvImagePtr bridge;
-  try
-  {
-    bridge = cv_bridge::toCvCopy(image_msg, "mono8");  // TODO: was rgb8? does this work?
-  }
-  catch(cv_bridge::Exception& e)
-  {
-    RCLCPP_ERROR(LOGGER, "Conversion failed");
-    return false;
-  }
-
-  // Find checkerboard
   std::vector<cv::Point2f> points;
-  points.resize(points_x_ * points_y_);
-  cv::Size checkerboard_size(points_x_, points_y_);
-  int found = cv::findChessboardCorners(bridge->image, checkerboard_size,
-                                        points, cv::CALIB_CB_ADAPTIVE_THRESH);
-
-  if (found)
+  if (findCheckerboardPoints(image_msg, points))
   {
     RCLCPP_INFO(LOGGER, "Found the checkboard");
 
@@ -208,7 +196,7 @@ bool CheckerboardFinder::findInternal(robot_calibration_msgs::msg::CalibrationDa
     cloud.width = 0;
     cloud.height = 0;
     cloud.header.stamp = clock_->now();
-    cloud.header.frame_id = cloud_.header.frame_id;
+    cloud.header.frame_id = msg_.header.frame_id;
     sensor_msgs::PointCloud2Modifier cloud_mod(cloud);
     cloud_mod.setPointCloud2FieldsByString(1, "xyz");
     cloud_mod.resize(points_x_ * points_y_);
@@ -225,18 +213,18 @@ bool CheckerboardFinder::findInternal(robot_calibration_msgs::msg::CalibrationDa
     msg->observations[idx_chain].features.resize(points_x_ * points_y_);
 
     // Fill in the headers
-    rgbd.header = cloud_.header;
+    rgbd.header = msg_.header;
     world.header.frame_id = frame_id_;
 
     // Fill in message
-    sensor_msgs::PointCloud2ConstIterator<float> xyz(cloud_, "x");
+    sensor_msgs::PointCloud2ConstIterator<float> xyz(msg_, "x");
     for (size_t i = 0; i < points.size(); ++i)
     {
       world.point.x = (i % points_x_) * square_size_;
       world.point.y = (i / points_x_) * square_size_;
 
       // Get 3d point
-      int index = (int)(points[i].y) * cloud_.width + (int)(points[i].x);
+      int index = (int)(points[i].y) * msg_.width + (int)(points[i].x);
       rgbd.point.x = (xyz + index)[X];
       rgbd.point.y = (xyz + index)[Y];
       rgbd.point.z = (xyz + index)[Z];
@@ -264,7 +252,7 @@ bool CheckerboardFinder::findInternal(robot_calibration_msgs::msg::CalibrationDa
     // Add debug cloud to message
     if (output_debug_)
     {
-      msg->observations[idx_cam].cloud = cloud_;
+      msg->observations[idx_cam].cloud = msg_;
     }
 
     // Publish results
@@ -277,7 +265,30 @@ bool CheckerboardFinder::findInternal(robot_calibration_msgs::msg::CalibrationDa
   return false;
 }
 
+template <typename T>
+bool CheckerboardFinder<T>::findCheckerboardPoints(sensor_msgs::msg::Image::SharedPtr image,
+                                                   std::vector<cv::Point2f>& points)
+{
+  // Get an OpenCV image from the cloud
+  cv_bridge::CvImagePtr bridge;
+  try
+  {
+    bridge = cv_bridge::toCvCopy(image, "mono8");  // TODO: was rgb8? does this work?
+  }
+  catch(cv_bridge::Exception& e)
+  {
+    RCLCPP_ERROR(LOGGER, "Conversion failed");
+    return false;
+  }
+
+  // Find checkerboard
+  points.resize(points_x_ * points_y_);
+  cv::Size checkerboard_size(points_x_, points_y_);
+  return cv::findChessboardCorners(bridge->image, checkerboard_size,
+                                   points, cv::CALIB_CB_ADAPTIVE_THRESH);
+}
+
 }  // namespace robot_calibration
 
 #include <pluginlib/class_list_macros.hpp>
-PLUGINLIB_EXPORT_CLASS(robot_calibration::CheckerboardFinder, robot_calibration::FeatureFinder)
+PLUGINLIB_EXPORT_CLASS(robot_calibration::CheckerboardFinder<sensor_msgs::msg::PointCloud2>, robot_calibration::FeatureFinder)

--- a/robot_calibration/test/feature_finder_loader_tests.cpp
+++ b/robot_calibration/test/feature_finder_loader_tests.cpp
@@ -25,7 +25,7 @@ TEST(FeatureFinderLoaderTests, test_feature_finder_loader)
   bool result = loader.load(node, features);
 
   EXPECT_EQ(true, result);
-  EXPECT_EQ(static_cast<size_t>(2), features.size());
+  EXPECT_EQ(static_cast<size_t>(3), features.size());
 }
 
 int main(int argc, char** argv)

--- a/robot_calibration/test/feature_finder_loader_tests.yaml
+++ b/robot_calibration/test/feature_finder_loader_tests.yaml
@@ -2,10 +2,17 @@ feature_finder_loader_tests:
   ros__parameters:
     features:
     - checkerboard_finder
+    - checkerboard_finder_2d
     - ground_plane_finder
     checkerboard_finder:
       type: robot_calibration::CheckerboardFinder
       topic: /head_camera/depth_registered/points
+      camera_sensor_name: camera
+      chain_sensor_name: arm
+      camera_driver: /camera_info_publisher
+    checkerboard_finder_2d:
+      type: robot_calibration::CheckerboardFinder2d
+      topic: /head_camera/depth_registered/rgb
       camera_sensor_name: camera
       chain_sensor_name: arm
       camera_driver: /camera_info_publisher


### PR DESCRIPTION
This is the first step towards completing #41 

 * Refactors checkerboard finder to be templated on data type.
 * Uses template specialization to make 2d and 3d variants.
 * Updates test to load both variants.

This was tested on the UBR-1 using this configuration: https://github.com/mikeferguson/ubr_reloaded/commit/06587ccb0fbcf1c321e4b1d2acedd6c604a2c733