### PR TITLE
fix typo in test/CMakeLists.txt

### DIFF
--- a/robot_calibration/test/CMakeLists.txt
+++ b/robot_calibration/test/CMakeLists.txt
@@ -80,7 +80,7 @@ if(ENABLE_COVERAGE_TESTING)
   set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
   add_code_coverage(
     NAME ${PROJECT_NAME}_coverage_report
-    DEPENDS tests
+    DEPENDENCIES tests
   )
 endif()
 

--- a/robot_calibration/test/CMakeLists.txt
+++ b/robot_calibration/test/CMakeLists.txt
@@ -80,7 +80,7 @@ if(ENABLE_COVERAGE_TESTING)
   set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
   add_code_coverage(
     NAME ${PROJECT_NAME}_coverage_report
-    DEPENDENCIES tests
+    DEPENDENCIES _run_tests_${PROJECT_NAME}
   )
 endif()
 


### PR DESCRIPTION
this PR fix typo and use `DEPENDENCIES` for `add_code_coverage`.
As a result of https://github.com/mikeferguson/code_coverage/pull/36, it will fail to build the package because of cyclic dependencies.

```
_______________________________________________________________________________________________________________________________________
Errors     << robot_calibration:check /home/knorth55/gitai/coverage_ws/logs/robot_calibration/build.check.004.log
CMake Error: The inter-target dependency graph contains the following strongly connected component (cycle):
  "tests" of type UTILITY
    depends on "robot_calibration_coverage_report_cleanup_cpp" (strong)
  "robot_calibration_coverage_report_cleanup_cpp" of type UTILITY
    depends on "tests" (strong)
At least one of these targets is not a STATIC_LIBRARY.  Cyclic dependencies are allowed only among static libraries.
CMake Generate step failed.  Build files cannot be regenerated correctly.
make: *** [Makefile:2972: cmake_check_build_system] Error 1
cd /home/knorth55/gitai/coverage_ws/build/robot_calibration; catkin build --get-env robot_calibration | catkin env -si  /usr/bin/make cmake_check_build_system; cd -

.......................................................................................................................................
Failed     << robot_calibration:check               [ Exited with code 2 ]
Failed    <<< robot_calibration                     [ 1.5 seconds ]
```