### PR TITLE
temporarily depend on libfcl-dev

### DIFF
--- a/robot_calibration/package.xml
+++ b/robot_calibration/package.xml
@@ -23,6 +23,7 @@
   <depend>kdl_parser</depend>
   <depend>moveit_msgs</depend>
   <depend>nav_msgs</depend>
+  <depend>libfcl-dev</depend>
   <depend>liborocos-kdl-dev</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
The new release of geometric_shapes only exec_depends on libfcl, which appears to cause linking issues in building the Debians.