### PR TITLE
Parameterize velocity_threshold in ChainManager

### DIFF
--- a/robot_calibration/include/robot_calibration/util/chain_manager.hpp
+++ b/robot_calibration/include/robot_calibration/util/chain_manager.hpp
@@ -123,6 +123,8 @@ private:
 
   // Maximum time to wait (in seconds) for settling to occur
   double settling_timeout_;
+
+  double velocity_threshold_;
 };
 
 }  // namespace robot_calibration

--- a/robot_calibration/src/util/chain_manager.cpp
+++ b/robot_calibration/src/util/chain_manager.cpp
@@ -81,6 +81,8 @@ ChainManager::ChainManager(rclcpp::Node::SharedPtr node, long int wait_time) :
   // <= 0.0 disables timeout
   settling_timeout_ = node->declare_parameter<double>("settling_timeout", 0.0);
 
+  velocity_threshold_ = node->declare_parameter<double>("velocity_threshold", 0.001);
+
   subscriber_ = node->create_subscription<sensor_msgs::msg::JointState>(
     "/joint_states", 10, std::bind(&ChainManager::stateCallback, this, std::placeholders::_1));
 }
@@ -270,7 +272,7 @@ bool ChainManager::waitToSettle()
       for (size_t j = 0; j < state.name.size(); ++j)
       {
         // Is this joint even a concern?
-        if (fabs(state.velocity[j]) < 0.001)
+        if (fabs(state.velocity[j]) < velocity_threshold_)
           continue;
 
         for (size_t i = 0; i < controllers_.size(); ++i)


### PR DESCRIPTION
Currently, the velocity threshold used in waitToSettle() is hardcoded to 0.001. For some robots (such as the TIAGo family from PAL Robotics), the joint velocity noise level is slightly higher than this threshold. This causes the calibration process to hang or time out, even when the robot is physically still.
This PR makes velocity_threshold an ROS 2 parameter, enabling users to adjust it according to their hardware's specific noise profile.
Changes:
- Declared velocity_threshold as a parameter in ChainManager.
- Updated waitToSettle() to use this parameter instead of the hardcoded value.
- The default value of 0.001 has been maintained to ensure backward compatibility.